### PR TITLE
Add `skip_consent` to oEmbed data (TCUE-3526)

### DIFF
--- a/lib/oembed.js
+++ b/lib/oembed.js
@@ -36,6 +36,10 @@ exports.getOembed = function(uri, data, options) {
         oembed.videoId = data.meta.videoId;
     }
 
+    if (data.meta.skip_consent && data.meta.skip_consent === 'true') {
+        oembed.skip_consent = true;
+    }
+
     if (customVendorMapping) {
         var vendorId = customVendorMapping[oembed.provider_name];
         if (vendorId) {


### PR DESCRIPTION
Issue: TCUE-3526

This PR extends the oEmbed data by a `skip_consent` property if a corresponding property was found in the embed meta data.

## Related PRs
* https://github.com/urbanmedia/iframely-tgs/pull/23
* https://github.com/urbanmedia/tgs.frontend/pull/823